### PR TITLE
Add separate CPF validators using Serilog and ILogger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+bin/
+obj/
+**/bin/
+**/obj/

--- a/PocLogs.Api/Controllers/CpfILoggerController.cs
+++ b/PocLogs.Api/Controllers/CpfILoggerController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using PocLogs.Api.Models;
+using PocLogs.Api.Validators;
+
+namespace PocLogs.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class CpfILoggerController : ControllerBase
+{
+    private readonly CpfValidatorWithILogger _validator;
+
+    public CpfILoggerController(CpfValidatorWithILogger validator)
+    {
+        _validator = validator;
+    }
+
+    [HttpPost]
+    public ActionResult<bool> Post([FromBody] CpfRequest request)
+    {
+        bool valid = _validator.IsValid(request.Cpf);
+        return Ok(valid);
+    }
+}

--- a/PocLogs.Api/Controllers/CpfSerilogController.cs
+++ b/PocLogs.Api/Controllers/CpfSerilogController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Mvc;
+using PocLogs.Api.Models;
+using PocLogs.Api.Validators;
+
+namespace PocLogs.Api.Controllers;
+
+[ApiController]
+[Route("[controller]")]
+public class CpfSerilogController : ControllerBase
+{
+    private readonly CpfValidatorWithSerilog _validator;
+
+    public CpfSerilogController(CpfValidatorWithSerilog validator)
+    {
+        _validator = validator;
+    }
+
+    [HttpPost]
+    public ActionResult<bool> Post([FromBody] CpfRequest request)
+    {
+        bool valid = _validator.IsValid(request.Cpf);
+        return Ok(valid);
+    }
+}

--- a/PocLogs.Api/Models/CpfRequest.cs
+++ b/PocLogs.Api/Models/CpfRequest.cs
@@ -1,0 +1,3 @@
+namespace PocLogs.Api.Models;
+
+public record CpfRequest(string Cpf);

--- a/PocLogs.Api/PocLogs.Api.csproj
+++ b/PocLogs.Api/PocLogs.Api.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.16" />
+    <PackageReference Include="Serilog.AspNetCore" Version="7.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.6.2" />
   </ItemGroup>
 

--- a/PocLogs.Api/Program.cs
+++ b/PocLogs.Api/Program.cs
@@ -1,7 +1,19 @@
+using Serilog;
+using PocLogs.Api.Validators;
+
 var builder = WebApplication.CreateBuilder(args);
+
+builder.Host.UseSerilog((context, services, configuration) =>
+{
+    configuration
+        .ReadFrom.Configuration(context.Configuration)
+        .WriteTo.Console();
+});
 
 // Add services to the container.
 builder.Services.AddControllers();
+builder.Services.AddScoped<CpfValidatorWithILogger>();
+builder.Services.AddScoped<CpfValidatorWithSerilog>();
 // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
 builder.Services.AddEndpointsApiExplorer();
 builder.Services.AddSwaggerGen();

--- a/PocLogs.Api/Validators/CpfValidatorWithILogger.cs
+++ b/PocLogs.Api/Validators/CpfValidatorWithILogger.cs
@@ -1,0 +1,66 @@
+using Microsoft.Extensions.Logging;
+
+namespace PocLogs.Api.Validators;
+
+public class CpfValidatorWithILogger
+{
+    private readonly ILogger<CpfValidatorWithILogger> _logger;
+
+    public CpfValidatorWithILogger(ILogger<CpfValidatorWithILogger> logger)
+    {
+        _logger = logger;
+    }
+
+    public bool IsValid(string? cpf)
+    {
+        _logger.LogInformation("Starting validation for {Cpf}", cpf);
+        if (string.IsNullOrWhiteSpace(cpf))
+        {
+            _logger.LogInformation("CPF is null or empty");
+            return false;
+        }
+
+        cpf = new string(cpf.Where(char.IsDigit).ToArray());
+        _logger.LogInformation("Digits only: {Cpf}", cpf);
+        if (cpf.Length != 11)
+        {
+            _logger.LogInformation("Invalid length");
+            return false;
+        }
+
+        if (cpf.Distinct().Count() == 1)
+        {
+            _logger.LogInformation("All digits equal");
+            return false;
+        }
+
+        int[] numbers = cpf.Select(c => c - '0').ToArray();
+
+        int sum = 0;
+        for (int i = 0; i < 9; i++)
+            sum += numbers[i] * (10 - i);
+        int result = sum % 11;
+        int firstDigit = result < 2 ? 0 : 11 - result;
+        _logger.LogInformation("First digit calculated: {Digit}", firstDigit);
+        if (numbers[9] != firstDigit)
+        {
+            _logger.LogInformation("First digit mismatch");
+            return false;
+        }
+
+        sum = 0;
+        for (int i = 0; i < 10; i++)
+            sum += numbers[i] * (11 - i);
+        result = sum % 11;
+        int secondDigit = result < 2 ? 0 : 11 - result;
+        _logger.LogInformation("Second digit calculated: {Digit}", secondDigit);
+        if (numbers[10] != secondDigit)
+        {
+            _logger.LogInformation("Second digit mismatch");
+            return false;
+        }
+
+        _logger.LogInformation("CPF is valid");
+        return true;
+    }
+}

--- a/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
+++ b/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
@@ -1,0 +1,66 @@
+using Serilog;
+
+namespace PocLogs.Api.Validators;
+
+public class CpfValidatorWithSerilog
+{
+    private readonly Serilog.ILogger _logger;
+
+    public CpfValidatorWithSerilog(Serilog.ILogger logger)
+    {
+        _logger = logger;
+    }
+
+    public bool IsValid(string? cpf)
+    {
+        _logger.Information("Starting validation for {Cpf}", cpf);
+        if (string.IsNullOrWhiteSpace(cpf))
+        {
+            _logger.Information("CPF is null or empty");
+            return false;
+        }
+
+        cpf = new string(cpf.Where(char.IsDigit).ToArray());
+        _logger.Information("Digits only: {Cpf}", cpf);
+        if (cpf.Length != 11)
+        {
+            _logger.Information("Invalid length");
+            return false;
+        }
+
+        if (cpf.Distinct().Count() == 1)
+        {
+            _logger.Information("All digits equal");
+            return false;
+        }
+
+        int[] numbers = cpf.Select(c => c - '0').ToArray();
+
+        int sum = 0;
+        for (int i = 0; i < 9; i++)
+            sum += numbers[i] * (10 - i);
+        int result = sum % 11;
+        int firstDigit = result < 2 ? 0 : 11 - result;
+        _logger.Information("First digit calculated: {Digit}", firstDigit);
+        if (numbers[9] != firstDigit)
+        {
+            _logger.Information("First digit mismatch");
+            return false;
+        }
+
+        sum = 0;
+        for (int i = 0; i < 10; i++)
+            sum += numbers[i] * (11 - i);
+        result = sum % 11;
+        int secondDigit = result < 2 ? 0 : 11 - result;
+        _logger.Information("Second digit calculated: {Digit}", secondDigit);
+        if (numbers[10] != secondDigit)
+        {
+            _logger.Information("Second digit mismatch");
+            return false;
+        }
+
+        _logger.Information("CPF is valid");
+        return true;
+    }
+}

--- a/PocLogs.Tests/CpfControllerTests.cs
+++ b/PocLogs.Tests/CpfControllerTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging.Abstractions;
+using PocLogs.Api.Controllers;
+using PocLogs.Api.Models;
+using PocLogs.Api.Validators;
+using Serilog;
+
+namespace PocLogs.Tests;
+
+public class CpfControllerTests
+{
+    [Fact]
+    public void ILoggerController_ReturnsTrueForValidCpf()
+    {
+        var validator = new CpfValidatorWithILogger(new NullLogger<CpfValidatorWithILogger>());
+        var controller = new CpfILoggerController(validator);
+
+        var result = controller.Post(new CpfRequest("52998224725"));
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.True((bool)okResult.Value!);
+    }
+
+    [Fact]
+    public void SerilogController_ReturnsFalseForInvalidCpf()
+    {
+        var validator = new CpfValidatorWithSerilog(new LoggerConfiguration().CreateLogger());
+        var controller = new CpfSerilogController(validator);
+
+        var result = controller.Post(new CpfRequest("12345678900"));
+        var okResult = Assert.IsType<OkObjectResult>(result.Result);
+        Assert.False((bool)okResult.Value!);
+    }
+}


### PR DESCRIPTION
## Summary
- replace single `CpfController` with two controllers
- introduce `CpfValidatorWithSerilog` and `CpfValidatorWithILogger`
- log each validation step using the respective logging framework
- wire validators via DI and update tests

## Testing
- `dotnet test --verbosity minimal`
- `dotnet test --no-build --verbosity minimal`


------
https://chatgpt.com/codex/tasks/task_e_68487cd4832c832ca69052ba16f3b803