### PR TITLE
Add request correlation logging

### DIFF
--- a/PocLogs.Api/Middlewares/CorrelationIdMiddleware.cs
+++ b/PocLogs.Api/Middlewares/CorrelationIdMiddleware.cs
@@ -1,0 +1,31 @@
+using Microsoft.AspNetCore.Http;
+using Serilog.Context;
+
+namespace PocLogs.Api.Middlewares;
+
+public class CorrelationIdMiddleware
+{
+    private const string HeaderName = "X-Correlation-Id";
+    private readonly RequestDelegate _next;
+
+    public CorrelationIdMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public async Task InvokeAsync(HttpContext context)
+    {
+        var correlationId = context.Request.Headers[HeaderName].FirstOrDefault();
+        if (string.IsNullOrEmpty(correlationId))
+        {
+            correlationId = Guid.NewGuid().ToString();
+        }
+
+        context.Response.Headers[HeaderName] = correlationId;
+
+        using (LogContext.PushProperty("CorrelationId", correlationId))
+        {
+            await _next(context);
+        }
+    }
+}

--- a/PocLogs.Api/Program.cs
+++ b/PocLogs.Api/Program.cs
@@ -1,5 +1,6 @@
 using Serilog;
 using PocLogs.Api.Validators;
+using PocLogs.Api.Middlewares;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -28,6 +29,8 @@ if (app.Environment.IsDevelopment())
 }
 
 app.UseHttpsRedirection();
+
+app.UseMiddleware<CorrelationIdMiddleware>();
 
 app.UseAuthorization();
 


### PR DESCRIPTION
## Summary
- add middleware to enrich logs with a correlation id
- wire middleware in Program.cs to include the ID on each request

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68496753234c832c919f0eebe61cca8b