### PR TITLE
Optimize CPF validators

### DIFF
--- a/PocLogs.Api/Validators/CpfValidatorLogMessages.cs
+++ b/PocLogs.Api/Validators/CpfValidatorLogMessages.cs
@@ -1,0 +1,36 @@
+using Microsoft.Extensions.Logging;
+
+namespace PocLogs.Api.Validators;
+
+internal static partial class CpfValidatorLogMessages
+{
+    [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Starting validation for {Cpf}")]
+    public static partial void StartingValidation(ILogger logger, string? cpf);
+
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "CPF is null or empty")]
+    public static partial void CpfNullOrEmpty(ILogger logger);
+
+    [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Digits only: {Cpf}")]
+    public static partial void DigitsOnly(ILogger logger, string cpf);
+
+    [LoggerMessage(EventId = 3, Level = LogLevel.Information, Message = "Invalid length")]
+    public static partial void InvalidLength(ILogger logger);
+
+    [LoggerMessage(EventId = 4, Level = LogLevel.Information, Message = "All digits equal")]
+    public static partial void AllDigitsEqual(ILogger logger);
+
+    [LoggerMessage(EventId = 5, Level = LogLevel.Information, Message = "First digit calculated: {Digit}")]
+    public static partial void FirstDigitCalculated(ILogger logger, int digit);
+
+    [LoggerMessage(EventId = 6, Level = LogLevel.Information, Message = "First digit mismatch")]
+    public static partial void FirstDigitMismatch(ILogger logger);
+
+    [LoggerMessage(EventId = 7, Level = LogLevel.Information, Message = "Second digit calculated: {Digit}")]
+    public static partial void SecondDigitCalculated(ILogger logger, int digit);
+
+    [LoggerMessage(EventId = 8, Level = LogLevel.Information, Message = "Second digit mismatch")]
+    public static partial void SecondDigitMismatch(ILogger logger);
+
+    [LoggerMessage(EventId = 9, Level = LogLevel.Information, Message = "CPF is valid")]
+    public static partial void CpfValid(ILogger logger);
+}

--- a/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
+++ b/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
@@ -13,38 +13,65 @@ public class CpfValidatorWithSerilog
 
     public bool IsValid(string? cpf)
     {
-        _logger.Information("Starting validation for {Cpf}", cpf);
+        if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+        {
+            _logger.Information("Starting validation for {Cpf}", cpf);
+        }
         if (string.IsNullOrWhiteSpace(cpf))
         {
-            _logger.Information("CPF is null or empty");
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+                _logger.Information("CPF is null or empty");
             return false;
         }
 
-        cpf = new string(cpf.Where(char.IsDigit).ToArray());
-        _logger.Information("Digits only: {Cpf}", cpf);
+        Span<char> digits = cpf.Length <= 32 ? stackalloc char[cpf.Length] : new char[cpf.Length];
+        int idx = 0;
+        foreach (var ch in cpf)
+        {
+            if (char.IsDigit(ch))
+                digits[idx++] = ch;
+        }
+        cpf = new string(digits.Slice(0, idx));
+        if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+            _logger.Information("Digits only: {Cpf}", cpf);
         if (cpf.Length != 11)
         {
-            _logger.Information("Invalid length");
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+                _logger.Information("Invalid length");
             return false;
         }
 
-        if (cpf.Distinct().Count() == 1)
+        bool allEqual = true;
+        for (int i = 1; i < cpf.Length; i++)
         {
-            _logger.Information("All digits equal");
+            if (cpf[i] != cpf[0])
+            {
+                allEqual = false;
+                break;
+            }
+        }
+        if (allEqual)
+        {
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+                _logger.Information("All digits equal");
             return false;
         }
 
-        int[] numbers = cpf.Select(c => c - '0').ToArray();
+        int[] numbers = new int[11];
+        for (int i = 0; i < 11; i++)
+            numbers[i] = cpf[i] - '0';
 
         int sum = 0;
         for (int i = 0; i < 9; i++)
             sum += numbers[i] * (10 - i);
         int result = sum % 11;
         int firstDigit = result < 2 ? 0 : 11 - result;
-        _logger.Information("First digit calculated: {Digit}", firstDigit);
+        if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+            _logger.Information("First digit calculated: {Digit}", firstDigit);
         if (numbers[9] != firstDigit)
         {
-            _logger.Information("First digit mismatch");
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+                _logger.Information("First digit mismatch");
             return false;
         }
 
@@ -53,14 +80,17 @@ public class CpfValidatorWithSerilog
             sum += numbers[i] * (11 - i);
         result = sum % 11;
         int secondDigit = result < 2 ? 0 : 11 - result;
-        _logger.Information("Second digit calculated: {Digit}", secondDigit);
+        if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+            _logger.Information("Second digit calculated: {Digit}", secondDigit);
         if (numbers[10] != secondDigit)
         {
-            _logger.Information("Second digit mismatch");
+            if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+                _logger.Information("Second digit mismatch");
             return false;
         }
 
-        _logger.Information("CPF is valid");
+        if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
+            _logger.Information("CPF is valid");
         return true;
     }
 }


### PR DESCRIPTION
## Summary
- refactor `CpfValidatorWithILogger` to remove LINQ allocations and use `LoggerMessage` for precompiled logs
- add `CpfValidatorLogMessages` helper for source-generated log messages
- improve `CpfValidatorWithSerilog` with allocation-free loops and log level checks

## Testing
- `dotnet build --no-restore`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684971cdc618832c9d535c91153a6447