### PR TITLE
Add benchmark unit test

### DIFF
--- a/PocLogs.Tests/BenchmarkTests.cs
+++ b/PocLogs.Tests/BenchmarkTests.cs
@@ -1,0 +1,19 @@
+using BenchmarkDotNet.Running;
+
+namespace PocLogs.Tests;
+
+public class BenchmarkTests
+{
+    [Fact]
+    public void CpfValidationBenchmark_ShouldHaveMeanBelowOneSecond()
+    {
+        var summary = BenchmarkRunner.Run<CpfValidationBenchmark>();
+        foreach (var report in summary.Reports)
+        {
+            Assert.NotNull(report.ResultStatistics);
+            var meanNanoseconds = report.ResultStatistics!.Mean;
+            double meanSeconds = meanNanoseconds / 1_000_000_000.0;
+            Assert.True(meanSeconds < 1, $"Benchmark {report.BenchmarkCase.DisplayInfo} took {meanSeconds} seconds on average");
+        }
+    }
+}

--- a/PocLogs.Tests/PocLogs.Tests.csproj
+++ b/PocLogs.Tests/PocLogs.Tests.csproj
@@ -20,10 +20,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.8" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\PocLogs.Api\PocLogs.Api.csproj" />
+    <ProjectReference Include="..\PocLogs.Benchmarks\PocLogs.Benchmarks.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- add BenchmarkDotNet reference to test project
- reference benchmark project from tests
- create BenchmarkTests that asserts the benchmark mean is below 1 second

## Testing
- `dotnet test PocLogs.sln -l "console;verbosity=minimal"`

------
https://chatgpt.com/codex/tasks/task_e_684981cfc674832c8f0c08a864e7149a