### PR TITLE
Refactor to non-nullable references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+Before committing any changes, run:
+1. `dotnet build`
+2. `dotnet test`
+If any build or test fails, fix the errors before committing.

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/PocLogs.Api/Middlewares/CorrelationIdMiddleware.cs
+++ b/PocLogs.Api/Middlewares/CorrelationIdMiddleware.cs
@@ -15,11 +15,8 @@ public class CorrelationIdMiddleware
 
     public async Task InvokeAsync(HttpContext context)
     {
-        var correlationId = context.Request.Headers[HeaderName].FirstOrDefault();
-        if (string.IsNullOrEmpty(correlationId))
-        {
-            correlationId = Guid.NewGuid().ToString();
-        }
+        var correlationId = context.Request.Headers[HeaderName]
+            .FirstOrDefault() ?? Guid.NewGuid().ToString();
 
         context.Response.Headers[HeaderName] = correlationId;
 

--- a/PocLogs.Api/Validators/CpfValidatorLogMessages.cs
+++ b/PocLogs.Api/Validators/CpfValidatorLogMessages.cs
@@ -5,9 +5,9 @@ namespace PocLogs.Api.Validators;
 internal static partial class CpfValidatorLogMessages
 {
     [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "Starting validation for {Cpf}")]
-    public static partial void StartingValidation(ILogger logger, string? cpf);
+    public static partial void StartingValidation(ILogger logger, string cpf);
 
-    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "CPF is null or empty")]
+    [LoggerMessage(EventId = 1, Level = LogLevel.Information, Message = "CPF is empty or whitespace")]
     public static partial void CpfNullOrEmpty(ILogger logger);
 
     [LoggerMessage(EventId = 2, Level = LogLevel.Information, Message = "Digits only: {Cpf}")]

--- a/PocLogs.Api/Validators/CpfValidatorWithILogger.cs
+++ b/PocLogs.Api/Validators/CpfValidatorWithILogger.cs
@@ -11,7 +11,7 @@ public class CpfValidatorWithILogger
         _logger = logger;
     }
 
-    public bool IsValid(string? cpf)
+    public bool IsValid(string cpf)
     {
         CpfValidatorLogMessages.StartingValidation(_logger, cpf);
         if (string.IsNullOrWhiteSpace(cpf))

--- a/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
+++ b/PocLogs.Api/Validators/CpfValidatorWithSerilog.cs
@@ -11,7 +11,7 @@ public class CpfValidatorWithSerilog
         _logger = logger;
     }
 
-    public bool IsValid(string? cpf)
+    public bool IsValid(string cpf)
     {
         if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
         {
@@ -20,7 +20,7 @@ public class CpfValidatorWithSerilog
         if (string.IsNullOrWhiteSpace(cpf))
         {
             if (_logger.IsEnabled(Serilog.Events.LogEventLevel.Information))
-                _logger.Information("CPF is null or empty");
+                _logger.Information("CPF is empty or whitespace");
             return false;
         }
 


### PR DESCRIPTION
## Summary
- centralize nullable reference enabling via `Directory.Build.props`
- use default correlation ID if header absent
- adjust CPF validators to require non-nullable strings
- update log message for empty CPF
- add repo instructions to run `dotnet build` and `dotnet test` before committing

## Testing
- `dotnet build`
- `dotnet test --no-build`


------
https://chatgpt.com/codex/tasks/task_e_684ac18c5164832cac1ddf35e7cf20d0