### PR TITLE
Corrige comando de cobertura

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Executar testes com cobertura
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
-          dotnet-coverage collect 'dotnet test --no-build' -f cobertura -o coverage.cobertura.xml
+          dotnet-coverage collect --output coverage.cobertura.xml --format cobertura -- dotnet test --no-build
       - name: Publicar artefatos
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Descrição
- corrige a invocação do `dotnet-coverage` na action de cobertura

## Testes realizados
- `dotnet build`
- `dotnet test`
- `dotnet test --collect:"XPlat Code Coverage"`


------
https://chatgpt.com/codex/tasks/task_e_684b41034a7c832c894208ce3734ee0e