### PR TITLE
Ajuste no comando dotnet-coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Executar testes com cobertura
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
-          dotnet-coverage collect 'dotnet test --no-build' -f cobertura -o coverage.cobertura.xml
+          dotnet-coverage collect -f cobertura -o coverage.cobertura.xml -- dotnet test --no-build
       - name: Publicar artefatos
         uses: actions/upload-artifact@v4
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ bin/
 obj/
 **/bin/
 **/obj/
+
+TestResults/
+CoverageReport/


### PR DESCRIPTION
## Resumo
- corrigido comando `dotnet-coverage` no workflow de cobertura
- adicionado `TestResults/` e `CoverageReport/` ao `.gitignore`

## Testes
- `dotnet build`
- `dotnet test --no-build`
- `dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory TestResults`


------
https://chatgpt.com/codex/tasks/task_e_684b4308db24832c8ff314142a5cdf9a