### PR TITLE
Adicionar publicação automática da wiki

### DIFF
--- a/.github/workflows/publish-wiki.yml
+++ b/.github/workflows/publish-wiki.yml
@@ -1,0 +1,20 @@
+name: Publicar Wiki
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - 'wiki/**'
+      - '.github/workflows/publish-wiki.yml'
+concurrency:
+  group: publish-wiki
+  cancel-in-progress: true
+permissions:
+  contents: write
+jobs:
+  publicar-wiki:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Andrew-Chen-Wang/github-wiki-action@v4
+        with:
+          path: wiki

--- a/README.md
+++ b/README.md
@@ -40,3 +40,4 @@ cobertura em Markdown. O resumo é exibido diretamente no workflow do GitHub.
 ## Documentação Completa
 
 Todo o material detalhado sobre arquitetura, rotas, validação de CPF e execução do projeto está disponível na [Wiki](wiki/Home.md). Consulte a Wiki para mais informações.
+As páginas localizadas no diretório `wiki/` são publicadas automaticamente na Wiki do GitHub por meio de um workflow de integração contínua.


### PR DESCRIPTION
## Resumo
- criar workflow `publish-wiki.yml` para publicar o conteúdo de `wiki/`
- documentar no README que a wiki é publicada automaticamente

## Testes
- `dotnet build PocLogs.sln`
- `dotnet test PocLogs.sln --no-build`
- `dotnet test --collect:"XPlat Code Coverage"`
- `reportgenerator -reports:**/coverage.cobertura.xml -targetdir:coverageReport -reporttypes:TextSummary`


------
https://chatgpt.com/codex/tasks/task_e_684c51febf90832cb8371bd52daf6740