### PR TITLE
Fix wiki links

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ bin/
 obj/
 **/bin/
 **/obj/
+TestResults/

--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ cobertura em Markdown. O resumo é exibido diretamente no workflow do GitHub.
 
 ## Documentação Completa
 
-Todo o material detalhado sobre arquitetura, rotas, validação de CPF e execução do projeto está disponível na [Wiki](wiki/Home.md). Consulte a Wiki para mais informações.
+Todo o material detalhado sobre arquitetura, rotas, validação de CPF e execução do projeto está disponível na [Wiki](https://github.com/AlbertKellner/PocLogs/wiki). Consulte a Wiki para mais informações.
 As páginas localizadas no diretório `wiki/` são publicadas automaticamente na Wiki do GitHub por meio de um workflow de integração contínua.


### PR DESCRIPTION
## Summary
- corrige o link da Wiki para abrir a documentação
- ignora diretórios de resultados de testes

## Testing
- `dotnet build`
- `dotnet test`
- `dotnet test --collect:"XPlat Code Coverage"`

------
https://chatgpt.com/codex/tasks/task_e_684c74d3a370832cbff60ad05cc65a3d