### PR TITLE
Documentação de infraestrutura

### DIFF
--- a/wiki/Arquitetura.md
+++ b/wiki/Arquitetura.md
@@ -13,3 +13,19 @@ A API define três controllers:
 - `CpfSerilogController`
 
 O middleware `CorrelationIdMiddleware` injeta o cabeçalho `X-Correlation-Id` em todas as respostas, facilitando o rastreamento dos logs.
+
+## Injeção de Dependência e Middleware
+
+Os validadores de CPF são registrados como serviços `Scoped` no `Program.cs` e o Serilog é configurado como provedor de logs padrão. O middleware `CorrelationIdMiddleware` é adicionado ao pipeline para garantir um identificador de correlação em cada requisição.
+
+```csharp
+builder.Services.AddScoped<CpfValidatorWithILogger>();
+builder.Services.AddScoped<CpfValidatorWithSerilog>();
+app.UseMiddleware<CorrelationIdMiddleware>();
+```
+
+## Frameworks
+
+Além do ASP.NET Core, o projeto utiliza Serilog para logs, xUnit e BenchmarkDotNet para testes e medições de desempenho, e o Swashbuckle para geração do Swagger.
+
+Detalhes de infraestrutura e organização de pastas podem ser vistos em [Infraestrutura](Infraestrutura).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -8,5 +8,6 @@ Nesta seção você encontra:
 - [Endpoints](Endpoints) – rotas disponíveis e exemplos de uso.
 - [Validação de CPF](ValidacaoCpf) – detalhes do algoritmo de verificação.
 - [Testes](Testes) – como executar e o que é coberto.
+- [Infraestrutura](Infraestrutura) – frameworks utilizados e estrutura de pastas.
 
 Consulte também a documentação da [execução do projeto](Execucao) para rodar a aplicação localmente.

--- a/wiki/Infraestrutura.md
+++ b/wiki/Infraestrutura.md
@@ -1,0 +1,35 @@
+# Infraestrutura e Estrutura de Pastas
+
+Esta seção descreve o ambiente e a organização do projeto.
+
+## Frameworks Utilizados
+
+- **.NET 8** – plataforma principal para a API e testes.
+- **ASP.NET Core** – base para a aplicação web.
+- **Serilog** – biblioteca de logs assíncronos exibidos no console.
+- **xUnit** – framework de testes unitários.
+- **BenchmarkDotNet** – executa medições de desempenho.
+- **Swashbuckle** – gera a documentação Swagger.
+
+## Injeção de Dependência
+
+Os serviços são registrados no `Program.cs` com o contêiner padrão do ASP.NET Core:
+
+```csharp
+builder.Services.AddControllers();
+builder.Services.AddScoped<CpfValidatorWithILogger>();
+builder.Services.AddScoped<CpfValidatorWithSerilog>();
+```
+
+O Serilog é configurado durante a criação do host e o middleware `CorrelationIdMiddleware` é adicionado ao pipeline.
+
+## Estrutura de Pastas
+
+- **PocLogs.Api** – controllers, middlewares, validadores e modelos da API.
+- **PocLogs.Tests** – testes automatizados e benchmarks.
+- **PocLogs.Benchmarks** – projeto auxiliar usado pelos benchmarks.
+- **wiki** – documentação que é publicada automaticamente na Wiki do GitHub.
+
+## Regras de Negócio
+
+A principal regra implementada é a [validação de CPF](ValidacaoCpf), utilizada pelos controllers de CPF. Cada requisição executa múltiplas validações para gerar logs e medir desempenho.


### PR DESCRIPTION
## Resumo
- documenta a infraestrutura e a organização de pastas
- adiciona link na Home da wiki
- detalha DI e frameworks usados na página de arquitetura

## Testes
- `dotnet build`
- `dotnet test --no-build`
- `dotnet test --no-build --collect:"XPlat Code Coverage" --results-directory TestResults --settings coverlet.runsettings`

------
https://chatgpt.com/codex/tasks/task_e_684d7a939b90832cacea3373345900d8